### PR TITLE
Add Twitter datasets processing support

### DIFF
--- a/data/processed/twitter_covid_es/twitter_covid_es.jsonl
+++ b/data/processed/twitter_covid_es/twitter_covid_es.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3b0a11dea4e1255545c52d6eb183c4cacfa2f5ecad89f5228ddd498e41a5dac
+size 14917

--- a/data/processed/twitter_covid_es/twitter_covid_es_report.json
+++ b/data/processed/twitter_covid_es/twitter_covid_es_report.json
@@ -1,0 +1,13 @@
+{
+    "num_docs": 20,
+    "num_words_split": 729,
+    "num_words_punct_spacy": 976,
+    "num_words_no_punct_spacy": 807,
+    "num_chars": 5495,
+    "sum_lang_score": 19.907523214817047,
+    "avg_words_split": 36.45,
+    "avg_words_punct_spacy": 48.8,
+    "avg_words_no_punct_spacy": 40.35,
+    "avg_chars": 274.75,
+    "avg_language_score": 0.9953761607408523
+}

--- a/data/processed/twitter_covid_py/twitter_covid_py.jsonl
+++ b/data/processed/twitter_covid_py/twitter_covid_py.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ce5703ab615fcb16e558c762da96f33b662ba46622f890efee1d6c388dc6b74
+size 1475

--- a/data/processed/twitter_covid_py/twitter_covid_py_report.json
+++ b/data/processed/twitter_covid_py/twitter_covid_py_report.json
@@ -1,0 +1,13 @@
+{
+    "num_docs": 2,
+    "num_words_split": 72,
+    "num_words_punct_spacy": 95,
+    "num_words_no_punct_spacy": 80,
+    "num_chars": 525,
+    "sum_lang_score": 1.9873734712600708,
+    "avg_words_split": 36.0,
+    "avg_words_punct_spacy": 47.5,
+    "avg_words_no_punct_spacy": 40.0,
+    "avg_chars": 262.5,
+    "avg_language_score": 0.9936867356300354
+}

--- a/data/processed/twitter_giossa_october/twitter_giossa_october.jsonl
+++ b/data/processed/twitter_giossa_october/twitter_giossa_october.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eb5e14160b74ca74c536dc8e6a38daf2dfeb13c12291bfcfdd4950a4bdb4dd6
+size 2224436

--- a/data/processed/twitter_giossa_october/twitter_giossa_october_report.json
+++ b/data/processed/twitter_giossa_october/twitter_giossa_october_report.json
@@ -1,0 +1,13 @@
+{
+    "num_docs": 4562,
+    "num_words_split": 45039,
+    "num_words_punct_spacy": 54581,
+    "num_words_no_punct_spacy": 48921,
+    "num_chars": 307359,
+    "sum_lang_score": 4379.601779103279,
+    "avg_words_split": 9.872643577378343,
+    "avg_words_punct_spacy": 11.964270056992547,
+    "avg_words_no_punct_spacy": 10.723586146427007,
+    "avg_chars": 67.37373958790005,
+    "avg_language_score": 0.9600179261515298
+}

--- a/data/processed/twitter_politic_bots/twitter_politic_bots.jsonl
+++ b/data/processed/twitter_politic_bots/twitter_politic_bots.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d683803b0921a2ee147e87637b98cf088570243ecaad9423c30dd849a8cf89f8
+size 23375

--- a/data/processed/twitter_politic_bots/twitter_politic_bots_report.json
+++ b/data/processed/twitter_politic_bots/twitter_politic_bots_report.json
@@ -1,0 +1,13 @@
+{
+    "num_docs": 44,
+    "num_words_split": 554,
+    "num_words_punct_spacy": 676,
+    "num_words_no_punct_spacy": 594,
+    "num_chars": 4353,
+    "sum_lang_score": 40.91838324069977,
+    "avg_words_split": 12.590909090909092,
+    "avg_words_punct_spacy": 15.363636363636363,
+    "avg_words_no_punct_spacy": 13.5,
+    "avg_chars": 98.93181818181819,
+    "avg_language_score": 0.9299632554704492
+}

--- a/src/processor.py
+++ b/src/processor.py
@@ -12,19 +12,10 @@ from utils import create_jsonl, word_count_spacy, word_count_split, \
 
 MIN_LANG_SCORE = 0.70
 
+
 def process_parquet_files(dir_path):
     """
     Convert all `.parquet` files in a directory (recursively) to `.csv` format.
-
-    Traverses the given directory tree, finds all Parquet files, and converts each 
-    one into a corresponding CSV file using pandas with the PyArrow engine.
-    If a corresponding CSV already exists, it will be skipped.
-
-    Args:
-        dir_path (str): Path to the root directory containing Parquet files.
-
-    Returns:
-        None
     """
     for root, _, files in os.walk(dir_path):
         for filename in files:
@@ -40,37 +31,19 @@ def process_parquet_files(dir_path):
 def process_text(text, corpus_name, corpus_file_name, source, url, lang_code, lang_script):
     """
     Process and annotate a text sample with linguistic metadata and word counts.
-
-    Performs word counting using two methods (split and spaCy), identifies the 
-    language, and compiles metadata describing the text for corpus integration.
-
-    Args:
-        text (str): The input text sample.
-        corpus_name (str): Name of the corpus the text belongs to.
-        corpus_file_name (str): Name of the file the text was extracted from.
-        source (str): Source name or origin of the text.
-        url (str): URL of the original text (if available).
-        lang_code (str): Expected ISO 639-3 language code.
-        lang_script (str): Script code (e.g., "Latn", "Cyrl").
-
-    Returns:
-        tuple: A tuple containing:
-            - text_dict (dict): Dictionary with annotated text metadata.
-            - num_words_split (int)
-            - num_words_punct_spacy (int)
-            - num_words_no_punct_spacy (int)
-            - lang_score (float)
     """
     num_words_split = word_count_split(text)
     num_words_punct_spacy = word_count_spacy(text, include_punct=True)
     num_words_no_punct_spacy = word_count_spacy(text, include_punct=False)
     ident_result = identify_language(text.replace('\n', ' ').replace('\r', ' '))
     lang_score, lang_code, lang_score_source, lang_ident_method = 0.0, lang_code, None, None
+
     if ident_result:
         lang_score = ident_result['score']
         lang_code = ident_result['lang']
         lang_score_source = ident_result['source_score']
         lang_ident_method = ident_result['voting_method']
+
     text_dict = {
         'text': text,
         'corpus': corpus_name,
@@ -87,34 +60,25 @@ def process_text(text, corpus_name, corpus_file_name, source, url, lang_code, la
         'num_words_no_punct_spacy': num_words_no_punct_spacy,
         'num_chars': len(text)
     }
+
     return text_dict, num_words_split, num_words_punct_spacy, num_words_no_punct_spacy, lang_score
 
 
 def save_report(report_dict, report_file_path):
     """
     Generate and save a JSON report summarizing corpus statistics.
-
-    Updates an existing report if it exists, aggregates statistics, and computes
-    averages for word counts, characters, and language identification scores.
-
-    Args:
-        report_dict (dict): Dictionary containing corpus-level statistics.
-        report_file_path (str): File path to save or update the JSON report.
-
-    Returns:
-        None
     """
     if os.path.exists(report_file_path):
         with open(report_file_path, 'r') as f:
             e_report_dict = json.load(f)
-        # update dictionary if a previous report exist
+
         report_dict['num_docs'] += e_report_dict['num_docs']
         report_dict['num_words_split'] += e_report_dict['num_words_split']
         report_dict['num_words_punct_spacy'] += e_report_dict['num_words_punct_spacy']
         report_dict['num_words_no_punct_spacy'] += e_report_dict['num_words_no_punct_spacy']
         report_dict['num_chars'] += e_report_dict['num_chars']
         report_dict['sum_lang_score'] += e_report_dict['sum_lang_score']
-    
+
     if report_dict['num_docs'] > 0:
         report_dict['avg_words_split'] = report_dict['num_words_split'] / report_dict['num_docs']
         report_dict['avg_words_punct_spacy'] = report_dict['num_words_punct_spacy'] / report_dict['num_docs']
@@ -122,45 +86,31 @@ def save_report(report_dict, report_file_path):
         report_dict['avg_chars'] = report_dict['num_chars'] / report_dict['num_docs']
         report_dict['avg_language_score'] = report_dict['sum_lang_score'] / report_dict['num_docs']
     else:
-        print(f'No documents found in file, skipping report generation.')
-    
+        print('No documents found in file, skipping report generation.')
+
     save_to_json(report_dict, report_file_path)
 
 
 def save_processing(output_dir_path, corpus_name, data, writing_mode, report_dict):
     """
     Save processed corpus data and associated report to disk.
-
-    Creates a corpus-specific subdirectory (if missing), writes the processed
-    samples to a JSONL file, and saves statistical summaries to a JSON report.
-
-    Args:
-        output_dir_path (str): Directory path for output corpora.
-        corpus_name (str): Name of the corpus being processed.
-        data (list[dict]): List of text metadata dictionaries.
-        writing_mode (str): File write mode ('a' for append, 'w' for overwrite).
-        report_dict (dict): Aggregated statistics for the corpus.
-
-    Returns:
-        None
     """
     if data and report_dict:
         output_dir_path = os.path.join(output_dir_path, corpus_name)
         os.makedirs(output_dir_path, exist_ok=True)
+
         output_file_path = os.path.join(output_dir_path, f'{corpus_name}.jsonl')
         create_jsonl(data, output_file_path, writing_mode)
+
         report_file_path = os.path.join(output_dir_path, f'{corpus_name}_report.json')
         save_report(report_dict, report_file_path)
+
         print('\n')
 
 
 def get_report_dict():
     """
     Initialize an empty report dictionary for corpus statistics tracking.
-
-    Returns:
-        dict: Dictionary with zero-initialized counters for word counts,
-        character counts, and average statistics.
     """
     return {
         'num_docs': 0,
@@ -178,150 +128,164 @@ def get_report_dict():
 
 
 def get_domain(url):
-  try:
-    return urlparse(url).netloc
-  except:
-    return None
+    try:
+        return urlparse(url).netloc
+    except Exception:
+        return None
 
 
-def read_csv_corpus(file_path, sep=',', names=None, ignore_bad_lines=True, 
+def read_csv_corpus(file_path, sep=',', names=None, ignore_bad_lines=True,
                     drop_incomplete_records=True):
     """
     Read and clean a corpus from a CSV or TSV file.
-
-    Args:
-        file_path (str): Path to the CSV/TSV file.
-        sep (str, optional): Column separator (default ',').
-        names (list[str], optional): Custom column names.
-        ignore_bad_lines (bool, optional): Skip malformed lines (default True).
-        drop_incomplete_records (bool, optional): Drop rows with missing values (default True).
-
-    Returns:
-        pandas.DataFrame: Cleaned DataFrame containing corpus records.
     """
     if ignore_bad_lines:
-        df = pd.read_csv(file_path, sep=sep, encoding='utf-8', names=names, 
-                           on_bad_lines='skip')
+        df = pd.read_csv(
+            file_path,
+            sep=sep,
+            encoding='utf-8',
+            names=names,
+            on_bad_lines='skip'
+        )
     else:
         df = pd.read_csv(file_path, sep=sep, encoding='utf-8', names=names)
+
     if drop_incomplete_records:
         df = df.dropna()
+
     if 'fineweb-2' in file_path and 'removed' in file_path:
         df['domain'] = df['url'].apply(get_domain)
-        # Text in the `removed` set of fineweb-2 will be included according to 
-        # the following heuristics:
-        # 1. Text coming from Wikipedia in Guarani
+
         filtered_df = pd.DataFrame()
         filtered_df = pd.concat(
             [
                 filtered_df,
                 df.loc[
-                    (df.domain.str.contains('gn.wikipedia.org'))&\
-                    (~df.filter_reason.str.contains('duplicated_', regex=False))&\
+                    (df.domain.str.contains('gn.wikipedia.org')) &
+                    (~df.filter_reason.str.contains('duplicated_', regex=False)) &
                     (df.filter_reason != 'char_dup_ratio')
                 ]
             ]
         )
-        # 2. Text containing at least 90% of Guarani and published on `.py` domains 
+
         filtered_df = pd.concat(
             [
                 filtered_df,
                 df.loc[
-                    (df.domain.str.contains('gn.wikipedia.org'))&\
-                    (~df.filter_reason.str.contains('duplicated_', regex=False))&\
+                    (df.domain.str.contains('gn.wikipedia.org')) &
+                    (~df.filter_reason.str.contains('duplicated_', regex=False)) &
                     (df.filter_reason != 'char_dup_ratio')
                 ]
             ]
         )
-        # 3. Text containing at least 90% of Guarani and published on domains 
-        # containing the word `guarani`
+
         filtered_df = pd.concat(
             [
                 filtered_df,
                 df.loc[
-                    (df.domain.str.contains('gn.wikipedia.org'))&\
-                    (~df.filter_reason.str.contains('duplicated_', regex=False))&\
+                    (df.domain.str.contains('gn.wikipedia.org')) &
+                    (~df.filter_reason.str.contains('duplicated_', regex=False)) &
                     (df.filter_reason != 'char_dup_ratio')
                 ]
             ]
         )
+
         df = filtered_df.copy()
+
     if 'commonvoice' in file_path:
-        if not 'reported' in file_path:
+        if 'reported' not in file_path:
             reported_file_path = os.path.join(os.path.dirname(file_path), 'reported.tsv')
             reported_sentences_df = pd.read_csv(reported_file_path, sep='\t')
             df = pd.read_csv(file_path, sep='\t')
-            # get rid off of reported sentences
             df = df.loc[~df.sentence_id.isin(reported_sentences_df.sentence_id.unique())]
         else:
-            # return an empty if we're working with reported.tsv, which contains
-            # reports of bad quality sentences
             df = pd.DataFrame()
-        
+
     return df
 
 
-def process_csv_corpus(file_path, output_dir_path, corpus_name, text_col_name, 
-                       source_col_name='', url_col_name='', 
-                       lang_code='grn', lang_script='Latn', writing_mode='a', 
+def process_csv_corpus(file_path, output_dir_path, corpus_name, text_col_name,
+                       source_col_name='', url_col_name='',
+                       lang_code='grn', lang_script='Latn', writing_mode='a',
                        sep=',', names=None):
     """
     Process and export a text corpus stored in CSV/TSV format.
-
-    Reads text data, extracts metadata, performs linguistic analysis, and writes
-    processed records to a JSONL file with a corresponding report.
-
-    Args:
-        file_path (str): Path to the CSV or TSV corpus file.
-        output_dir_path (str): Directory for output corpus data.
-        corpus_name (str): Name of the corpus.
-        text_col_name (str or list[str]): Column containing the text.
-        source_col_name (str, optional): Column with source information.
-        url_col_name (str, optional): Column with URLs.
-        lang_code (str, optional): Default language code (default 'grn').
-        lang_script (str, optional): Default script code (default 'Latn').
-        writing_mode (str, optional): File mode for JSONL ('a' or 'w').
-        sep (str, optional): Field separator (default ',').
-        names (list[str], optional): Column names override.
-
-    Returns:
-        None
     """
-    gn_corpora = ('Alpaca-gn-gpt4','Alpaca-gn-gpt3.5','gn-multi-affective-alpaca','mala-monolingual-split','cc100_gn','FinePDF')
-    instruction_based_corpora  = ('Alpaca-gn-gpt4', 'Alpaca-gn-gpt3.5', 'gn-multi-affective-alpaca')
-    if corpus_name in gn_corpora:
+    gn_corpora = (
+        'Alpaca-gn-gpt4',
+        'Alpaca-gn-gpt3.5',
+        'gn-multi-affective-alpaca',
+        'mala-monolingual-split',
+        'cc100_gn',
+        'FinePDF',
+    )
+
+    twitter_corpora = (
+        'twitter_giossa_october',
+        'twitter_covid_es',
+        'twitter_covid_py',
+    )
+
+    instruction_based_corpora = (
+        'Alpaca-gn-gpt4',
+        'Alpaca-gn-gpt3.5',
+        'gn-multi-affective-alpaca',
+    )
+
+    if corpus_name in gn_corpora or corpus_name in twitter_corpora:
         df = read_csv_corpus(file_path, sep, names, drop_incomplete_records=False)
     else:
         df = read_csv_corpus(file_path, sep, names)
+
     if df.shape[0] > 0:
         print(f'Processing corpus: {"/".join(file_path.split("/")[-2:])}')
         report_dict = get_report_dict()
         corpus_file_name = file_path.split('/')[-1]
         data = []
+
         if corpus_name == 'multi-wiki-qa':
             for _, row in df.iterrows():
-                context, question, answer = row[text_col_name[0]], row[text_col_name[1]], row[text_col_name[2]]
+                context = row[text_col_name[0]]
+                question = row[text_col_name[1]]
+                answer = row[text_col_name[2]]
+
                 text = ""
+
                 if isinstance(context, str):
                     text += context
+
                 if isinstance(question, str):
                     text += f"\n\n{question}"
+
                 if isinstance(answer, str):
                     try:
                         answer_dict = ast.literal_eval(answer)
-                        text += f"\n\n{' '.join(answer_dict["text"])}"
+                        text += f"\n\n{' '.join(answer_dict['text'])}"
                     except Exception:
-                        pass                
+                        pass
+
                 if not text:
                     continue
+
                 source = row[source_col_name] if source_col_name in row else 'unknown'
                 url = row[url_col_name] if url_col_name in row else 'unknown'
-                text_dict, num_words_split, num_words_punct_spacy, num_words_no_punct_spacy, lang_score = \
-                    process_text(text, corpus_name, corpus_file_name, source, url, lang_code, lang_script)                
+
+                text_dict, num_words_split, num_words_punct_spacy, \
+                    num_words_no_punct_spacy, lang_score = process_text(
+                        text,
+                        corpus_name,
+                        corpus_file_name,
+                        source,
+                        url,
+                        lang_code,
+                        lang_script
+                    )
+
                 if text_dict['language'] != lang_code:
                     continue
                 if lang_score < MIN_LANG_SCORE:
                     continue
+
                 data.append(text_dict)
                 report_dict['num_docs'] += 1
                 report_dict['num_words_split'] += num_words_split
@@ -329,27 +293,45 @@ def process_csv_corpus(file_path, output_dir_path, corpus_name, text_col_name,
                 report_dict['num_words_no_punct_spacy'] += num_words_no_punct_spacy
                 report_dict['num_chars'] += len(text)
                 report_dict['sum_lang_score'] += lang_score
+
         elif corpus_name == 'moscar':
             for index, row in df.iterrows():
                 try:
-                    text_list = ast.literal_eval(row[text_col_name].replace('}\n', '},').replace('...\n ', ''))
+                    text_list = ast.literal_eval(
+                        row[text_col_name].replace('}\n', '},').replace('...\n ', '')
+                    )
                     metadata_list = ast.literal_eval(row[url_col_name])
                 except Exception as e:
                     print(f"Failed to convert line {index} from string: {e}")
                     continue
+
                 if isinstance(text_list, list):
                     text = '\n'.join([t['text'] for t in text_list])
                 else:
                     continue
+
+                url = 'unknown'
                 if isinstance(metadata_list, dict):
                     url = metadata_list.get('url', 'unknown')
+
                 source = 'unknown'
-                text_dict, num_words_split, num_words_punct_spacy, num_words_no_punct_spacy, lang_score = \
-                    process_text(text, corpus_name, corpus_file_name, source, url, lang_code, lang_script)
+
+                text_dict, num_words_split, num_words_punct_spacy, \
+                    num_words_no_punct_spacy, lang_score = process_text(
+                        text,
+                        corpus_name,
+                        corpus_file_name,
+                        source,
+                        url,
+                        lang_code,
+                        lang_script
+                    )
+
                 if text_dict['language'] != lang_code:
                     continue
                 if lang_score < MIN_LANG_SCORE:
                     continue
+
                 data.append(text_dict)
                 report_dict['num_docs'] += 1
                 report_dict['num_words_split'] += num_words_split
@@ -357,6 +339,7 @@ def process_csv_corpus(file_path, output_dir_path, corpus_name, text_col_name,
                 report_dict['num_words_no_punct_spacy'] += num_words_no_punct_spacy
                 report_dict['num_chars'] += len(text)
                 report_dict['sum_lang_score'] += lang_score
+
         else:
             for _, row in df.iterrows():
                 if corpus_name in instruction_based_corpora:
@@ -368,15 +351,27 @@ def process_csv_corpus(file_path, output_dir_path, corpus_name, text_col_name,
                     text = " ".join(parts)
                 else:
                     text = row[text_col_name]
+
                 if isinstance(text, str) and text.strip():
                     source = row[source_col_name] if source_col_name in row else 'unknown'
                     url = row[url_col_name] if url_col_name in row else 'unknown'
-                    text_dict, num_words_split, num_words_punct_spacy, num_words_no_punct_spacy, lang_score = \
-                        process_text(text, corpus_name, corpus_file_name, source, url, lang_code, lang_script)                    
+
+                    text_dict, num_words_split, num_words_punct_spacy, \
+                        num_words_no_punct_spacy, lang_score = process_text(
+                            text,
+                            corpus_name,
+                            corpus_file_name,
+                            source,
+                            url,
+                            lang_code,
+                            lang_script
+                        )
+
                     if text_dict['language'] != lang_code:
                         continue
                     if lang_score < MIN_LANG_SCORE:
                         continue
+
                     data.append(text_dict)
                     report_dict['num_docs'] += 1
                     report_dict['num_words_split'] += num_words_split
@@ -386,57 +381,78 @@ def process_csv_corpus(file_path, output_dir_path, corpus_name, text_col_name,
                     report_dict['sum_lang_score'] += lang_score
                 else:
                     print(f'Text {text} not an instance of string, excluding...')
+
             if corpus_name == 'americasnli':
                 text_collection = df['premise'].unique().tolist()
-                data.extend(process_text_collection(text_collection, report_dict, corpus_name,
-                                                    corpus_file_name, lang_code, lang_script))
-                
-        print(f'Finished processing {corpus_file_name}. From {df.shape[0]} lines, {report_dict["num_docs"]} were included')
+                data.extend(
+                    process_text_collection(
+                        text_collection,
+                        report_dict,
+                        corpus_name,
+                        corpus_file_name,
+                        lang_code,
+                        lang_script
+                    )
+                )
+
+        print(
+            f'Finished processing {corpus_file_name}. '
+            f'From {df.shape[0]} lines, {report_dict["num_docs"]} were included'
+        )
         save_processing(output_dir_path, corpus_name, data, writing_mode, report_dict)
 
 
 def read_txt_corpus(file_path):
     """
     Read a plain-text corpus file as a list of lines.
-
-    Args:
-        file_path (str): Path to the text file.
-
-    Returns:
-        list[str]: List of lines read from the file.
     """
     with open(file_path, 'r', encoding='utf-8') as f:
         f_lines = f.readlines()
     return f_lines
 
 
-def process_text_collection(content_collection, report_dict, corpus_name, 
+def process_text_collection(content_collection, report_dict, corpus_name,
                             corpus_file_name, lang_code, lang_script, line_prefix='',
                             separator=''):
     data = []
+
     for text in content_collection:
         text = text.strip()
+
         if text and isinstance(text, str):
             if line_prefix and not text.startswith(line_prefix):
                 continue
+
             if separator:
                 text = text.split(separator['str'])[separator['idx']]
+
             source = 'unknown'
             url = 'unknown'
+
             if 'opus-all' in corpus_name:
                 rgx = r"OPUS-(.*)_mono_gn.txt"
                 res = re.search(rgx, corpus_file_name)
                 try:
                     source = res.group(1)
-                except:
+                except Exception:
                     pass
+
             text_dict, num_words_split, num_words_punct_spacy, \
-                num_words_no_punct_spacy, lang_score = \
-                process_text(text, corpus_name, corpus_file_name, source, url, lang_code, lang_script)
+                num_words_no_punct_spacy, lang_score = process_text(
+                    text,
+                    corpus_name,
+                    corpus_file_name,
+                    source,
+                    url,
+                    lang_code,
+                    lang_script
+                )
+
             if text_dict['language'] != lang_code:
                 continue
             if lang_score < MIN_LANG_SCORE:
                 continue
+
             data.append(text_dict)
             report_dict['num_docs'] += 1
             report_dict['num_words_split'] += num_words_split
@@ -444,98 +460,74 @@ def process_text_collection(content_collection, report_dict, corpus_name,
             report_dict['num_words_no_punct_spacy'] += num_words_no_punct_spacy
             report_dict['num_chars'] += len(text)
             report_dict['sum_lang_score'] += lang_score
+
     return data
 
 
-def process_txt_corpus(file_path, output_dir_path, corpus_name, lang_code='grn', 
-                       lang_script='Latn', writing_mode='a', separator=None, 
+def process_txt_corpus(file_path, output_dir_path, corpus_name, lang_code='grn',
+                       lang_script='Latn', writing_mode='a', separator=None,
                        line_prefix=''):
     """
-    Process a line-based text corpus (e.g., `.txt`, `.gn` files).
-
-    Supports line filtering, optional prefix-based selection, and splitting lines
-    on custom separators. Each valid text line is analyzed and stored.
-
-    Args:
-        file_path (str): Path to the text file.
-        output_dir_path (str): Output directory path.
-        corpus_name (str): Name of the corpus.
-        lang_code (str, optional): Default language code (default 'grn').
-        lang_script (str, optional): Script code (default 'Latn').
-        writing_mode (str, optional): Write mode for output file.
-        separator (dict, optional): Dict specifying {'str': separator, 'idx': column index}.
-        line_prefix (str, optional): Only process lines starting with this prefix.
-
-    Returns:
-        None
+    Process a line-based text corpus.
     """
     print(f'Processing corpus: {"/".join(file_path.split("/")[-2:])}')
     report_dict = get_report_dict()
     f_lines = read_txt_corpus(file_path)
     corpus_file_name = file_path.split('/')[-1]
-    data = process_text_collection(f_lines, report_dict, corpus_name, 
-                                   corpus_file_name, lang_code, lang_script, 
-                                   line_prefix, separator)
+
+    data = process_text_collection(
+        f_lines,
+        report_dict,
+        corpus_name,
+        corpus_file_name,
+        lang_code,
+        lang_script,
+        line_prefix,
+        separator
+    )
+
     save_processing(output_dir_path, corpus_name, data, writing_mode, report_dict)
 
 
 def read_xml_corpus(file_path):
     """
     Parse an XML corpus and extract text segments.
-
-    Extracts text from all `<s>` elements within the XML document.
-
-    Args:
-        file_path (str): Path to the XML file.
-
-    Returns:
-        list[str]: List of text elements extracted from the XML structure.
     """
     tree = ET.parse(file_path)
-    root = tree.getroot()  # Get the root element
+    root = tree.getroot()
     text_list = []
-    for element in root.findall('.//s'):  # Find all 's' elements
+
+    for element in root.findall('.//s'):
         text_list.append(element.text)
+
     return text_list
 
 
-def process_xml_corpus(file_path, output_dir_path, corpus_name, lang_code='grn', 
+def process_xml_corpus(file_path, output_dir_path, corpus_name, lang_code='grn',
                        lang_script='Latn', writing_mode='a'):
     """
     Process and export an XML-based text corpus.
-
-    Parses XML structure, extracts sentences, performs word counting and 
-    language identification, and writes results to JSONL and report files.
-
-    Args:
-        file_path (str): Path to the XML file.
-        output_dir_path (str): Output directory for processed corpus.
-        corpus_name (str): Corpus identifier.
-        lang_code (str, optional): Default language code.
-        lang_script (str, optional): Script code.
-        writing_mode (str, optional): Output write mode.
-
-    Returns:
-        None
     """
     print(f'Processing corpus: {"/".join(file_path.split("/")[-2:])}')
     report_dict = get_report_dict()
     text_list = read_xml_corpus(file_path)
     corpus_file_name = file_path.split('/')[-1]
-    data = process_text_collection(text_list, report_dict, corpus_name,
-                                   corpus_file_name, lang_code, lang_script)
+
+    data = process_text_collection(
+        text_list,
+        report_dict,
+        corpus_name,
+        corpus_file_name,
+        lang_code,
+        lang_script
+    )
+
     save_processing(output_dir_path, corpus_name, data, writing_mode, report_dict)
 
 
 def read_jsonl_corpus(file_path):
     """
-    Read a JSONL (JSON Lines) corpus into memory.
-
-    Args:
-        file_path (str): Path to the JSONL file.
-
-    Returns:
-        list[dict]: List of JSON objects representing corpus entries.
+    Read a JSONL corpus into memory.
     """
     with open(file_path, 'r', encoding='utf-8') as f:
         f_data = []
@@ -545,39 +537,36 @@ def read_jsonl_corpus(file_path):
     return f_data
 
 
-def process_jsonl_corpus(file_path, output_dir_path, corpus_name, lang_code='grn', 
-                       lang_script='Latn', writing_mode='a'):
+def process_jsonl_corpus(file_path, output_dir_path, corpus_name, lang_code='grn',
+                         lang_script='Latn', writing_mode='a'):
     """
-    Process a corpus stored in JSON Lines (JSONL) format.
-
-    Iterates through JSON records, extracts relevant text fields (e.g., 
-    'flores_passage' and 'question'), analyzes them, and saves results.
-
-    Args:
-        file_path (str): Path to the JSONL corpus file.
-        output_dir_path (str): Directory for processed corpus.
-        corpus_name (str): Corpus name.
-        lang_code (str, optional): Language code.
-        lang_script (str, optional): Script code.
-        writing_mode (str, optional): File writing mode ('a' or 'w').
-
-    Returns:
-        None
+    Process a corpus stored in JSON Lines format.
     """
     print(f'Processing corpus: {"/".join(file_path.split("/")[-2:])}')
     data = []
     report_dict = get_report_dict()
     f_data = read_jsonl_corpus(file_path)
     corpus_file_name = file_path.split('/')[-1]
+
     for line in f_data:
         for text in [line.get('flores_passage'), line.get('question'), line.get('trg')]:
             if isinstance(text, str):
-                text_dict, num_words_split, num_words_punct_spacy, num_words_no_punct_spacy, lang_score = \
-                    process_text(text, corpus_name, corpus_file_name, 'unknown', 'unknown', lang_code, lang_script)
+                text_dict, num_words_split, num_words_punct_spacy, \
+                    num_words_no_punct_spacy, lang_score = process_text(
+                        text,
+                        corpus_name,
+                        corpus_file_name,
+                        'unknown',
+                        'unknown',
+                        lang_code,
+                        lang_script
+                    )
+
                 if text_dict['language'] != lang_code:
                     continue
                 if lang_score < MIN_LANG_SCORE:
                     continue
+
                 data.append(text_dict)
                 report_dict['num_docs'] += 1
                 report_dict['num_words_split'] += num_words_split
@@ -585,34 +574,21 @@ def process_jsonl_corpus(file_path, output_dir_path, corpus_name, lang_code='grn
                 report_dict['num_words_no_punct_spacy'] += num_words_no_punct_spacy
                 report_dict['num_chars'] += len(text)
                 report_dict['sum_lang_score'] += lang_score
+
     save_processing(output_dir_path, corpus_name, data, writing_mode, report_dict)
+
 
 def read_json_corpus(file_path):
     with open(file_path, 'r', encoding='utf-8') as f:
-        # "item" iterates through each array element without loading all of them
         for obj in ijson.items(f, 'item'):
-            yield obj 
+            yield obj
 
-def process_json_corpus(file_path, output_dir_path, corpus_name, lang_code='grn', 
-                       lang_script='Latn', writing_mode='a'):
+
+def process_json_corpus(file_path, output_dir_path, corpus_name, lang_code='grn',
+                        lang_script='Latn', writing_mode='a'):
     """
     Process a corpus stored in JSON format.
-
-    Iterates through JSON records, extracts relevant text fields (e.g., 
-    'flores_passage' and 'question'), analyzes them, and saves results.
-
-    Args:
-        file_path (str): Path to the JSONL corpus file.
-        output_dir_path (str): Directory for processed corpus.
-        corpus_name (str): Corpus name.
-        lang_code (str, optional): Language code.
-        lang_script (str, optional): Script code.
-        writing_mode (str, optional): File writing mode ('a' or 'w').
-
-    Returns:
-        None
     """
-
     print(f'Processing corpus: {"/".join(file_path.split("/")[-2:])}')
     data = []
     report_dict = get_report_dict()
@@ -620,29 +596,82 @@ def process_json_corpus(file_path, output_dir_path, corpus_name, lang_code='grn'
     corpus_file_name = file_path.split('/')[-1]
 
     for line in f_data:
+        if corpus_name == 'twitter_politic_bots':
+            tweet_obj = line.get('tweet_obj', {})
+            text = tweet_obj.get('full_text')
+
+            if not isinstance(text, str) or not text.strip():
+                continue
+
+            source = 'unknown'
+            url = 'unknown'
+
+            text_dict, num_words_split, num_words_punct_spacy, \
+                num_words_no_punct_spacy, lang_score = process_text(
+                    text,
+                    corpus_name,
+                    corpus_file_name,
+                    source,
+                    url,
+                    lang_code,
+                    lang_script
+                )
+
+            if text_dict['language'] != lang_code:
+                continue
+            if lang_score < MIN_LANG_SCORE:
+                continue
+
+            data.append(text_dict)
+            report_dict['num_docs'] += 1
+            report_dict['num_words_split'] += num_words_split
+            report_dict['num_words_punct_spacy'] += num_words_punct_spacy
+            report_dict['num_words_no_punct_spacy'] += num_words_no_punct_spacy
+            report_dict['num_chars'] += len(text)
+            report_dict['sum_lang_score'] += lang_score
+
+            continue
+
         lang = line['language']
         if lang != 'gn':
             continue
+
         source = line['source']
+
         if corpus_name == "apollomoedataset":
             conversations = line['conversations']
             text = ""
             for conv in conversations:
                 text += conv['value']
+
         elif corpus_name == "apollomoebench":
             if isinstance(line['question'], str):
                 text = line['question']
             else:
                 continue
+
             if isinstance(line['options'], str):
                 text += '\n\n' + line['options']
+
             if isinstance(line['answer'], str):
                 text += '\n\n' + line['answer']
-        text_dict, num_words_split, num_words_punct_spacy, num_words_no_punct_spacy, lang_score = process_text(text, corpus_name, corpus_file_name, source, 'unknown', lang_code, lang_script)
+
+        text_dict, num_words_split, num_words_punct_spacy, \
+            num_words_no_punct_spacy, lang_score = process_text(
+                text,
+                corpus_name,
+                corpus_file_name,
+                source,
+                'unknown',
+                lang_code,
+                lang_script
+            )
+
         if text_dict['language'] != lang_code:
             continue
         if lang_score < MIN_LANG_SCORE:
             continue
+
         data.append(text_dict)
         report_dict['num_docs'] += 1
         report_dict['num_words_split'] += num_words_split
@@ -650,139 +679,153 @@ def process_json_corpus(file_path, output_dir_path, corpus_name, lang_code='grn'
         report_dict['num_words_no_punct_spacy'] += num_words_no_punct_spacy
         report_dict['num_chars'] += len(text)
         report_dict['sum_lang_score'] += lang_score
+
     save_processing(output_dir_path, corpus_name, data, writing_mode, report_dict)
 
 
 def get_corpus_file_names(corpus_dir_path):
     """
     List all corpus files within a directory.
-
-    Args:
-        corpus_dir_path (str): Path to a corpus directory.
-
-    Returns:
-        list[str]: Filenames contained in the directory.
     """
     return os.listdir(corpus_dir_path)
 
-def prepare_processing_csv_corpus(corpus_dir_path, corpus_dir_name, filename, 
+
+def prepare_processing_csv_corpus(corpus_dir_path, corpus_dir_name, filename,
                                   processed_dir):
     """
     Identify corpus type and process a CSV-based corpus accordingly.
-
-    Determines schema and processing parameters based on the corpus name,
-    then delegates processing to `process_csv_corpus`.
-
-    Args:
-        corpus_dir_path (str): Directory containing corpus files.
-        corpus_dir_name (str): Corpus name identifier.
-        filename (str): File name to process.
-        processed_dir (str): Output directory for processed results.
-
-    Returns:
-        None
     """
     file_path = os.path.join(corpus_dir_path, filename)
+
     if 'jojajovai' in corpus_dir_name:
         text_col_name = 'gn'
         source_col_name = 'source'
         url_col_name = None
         corpus_name = 'jojajovai'
+
+    elif corpus_dir_name == 'twitter_giossa_october':
+        text_col_name = 'Tweet'
+        source_col_name = ''
+        url_col_name = ''
+        corpus_name = 'twitter_giossa_october'
+
+    elif corpus_dir_name == 'twitter_covid_es':
+        text_col_name = 'text'
+        source_col_name = 'source'
+        url_col_name = ''
+        corpus_name = 'twitter_covid_es'
+
+    elif corpus_dir_name == 'twitter_covid_py':
+        text_col_name = 'text'
+        source_col_name = 'source'
+        url_col_name = ''
+        corpus_name = 'twitter_covid_py'
+
     elif 'culturax' in corpus_dir_name:
         text_col_name = 'text'
         source_col_name = 'source'
         url_col_name = 'url'
         corpus_name = 'culturax'
+
     elif 'fineweb-2' in corpus_dir_name:
         text_col_name = 'text'
         source_col_name = ''
         url_col_name = 'url'
         corpus_name = 'fineweb-2'
+
     elif 'multi-wiki-qa' in corpus_dir_name:
         text_col_name = ['context', 'question', 'answers']
         source_col_name = ''
         url_col_name = 'id'
         corpus_name = 'multi-wiki-qa'
+
     elif 'flores-200' in corpus_dir_name:
         text_col_name = 'sentence_grn_Latn'
         source_col_name = 'domain'
         url_col_name = 'URL'
         corpus_name = 'flores-200'
+
     elif 'moscar' in corpus_dir_name:
         text_col_name = 'text'
         source_col_name = ''
         url_col_name = 'metadata'
         corpus_name = 'moscar'
+
     elif 'glot500' in corpus_dir_name:
         text_col_name = 'text'
         source_col_name = ''
         url_col_name = ''
         corpus_name = 'glot500'
+
     elif 'Alpaca-gn-gpt4' in corpus_dir_name:
         text_col_name = 'instruction'
         source_col_name = ''
         url_col_name = ''
         corpus_name = 'Alpaca-gn-gpt4'
+
     elif 'Alpaca-gn-gpt3.5' in corpus_dir_name:
         text_col_name = 'instruction'
         source_col_name = ''
         url_col_name = ''
         corpus_name = 'Alpaca-gn-gpt3.5'
+
     elif 'FinePDF' in corpus_dir_name:
         text_col_name = 'text'
         source_col_name = ''
         url_col_name = 'url'
         corpus_name = 'FinePDF'
+
     elif 'gn-multi-affective-alpaca' in corpus_dir_name:
         text_col_name = 'instruction'
         source_col_name = ''
         url_col_name = ''
         corpus_name = 'gn-multi-affective-alpaca'
+
     elif 'mala-monolingual-split' in corpus_dir_name:
         text_col_name = 'text'
         source_col_name = ''
         url_col_name = ''
         corpus_name = 'mala-monolingual-split'
+
     elif 'smolsent__en_gn' in corpus_dir_name:
         text_col_name = 'trg'
         source_col_name = ''
         url_col_name = ''
         corpus_name = 'smolsent__en_gn'
+
     elif 'cc100_gn' in corpus_dir_name:
         text_col_name = 'text'
         source_col_name = ''
         url_col_name = ''
         corpus_name = 'cc100_gn'
+
     elif 'udhr-lid' in corpus_dir_name:
         text_col_name = 'sentence'
         source_col_name = ''
         url_col_name = ''
         corpus_name = 'udhr-lid'
+
     else:
         raise Exception(f'Unknown corpus in path {corpus_dir_path}')
-    process_csv_corpus(file_path, processed_dir, corpus_name, text_col_name, 
-                       source_col_name, url_col_name)
+
+    process_csv_corpus(
+        file_path,
+        processed_dir,
+        corpus_name,
+        text_col_name,
+        source_col_name,
+        url_col_name
+    )
 
 
 def prepare_processing_txt_corpus(corpus_dir_path, corpus_dir_name, filename,
                                   processed_dir):
     """
     Configure and process a text corpus file.
-
-    Applies corpus-specific preprocessing logic (e.g., separators, line prefixes),
-    then calls `process_txt_corpus`.
-
-    Args:
-        corpus_dir_path (str): Path to the corpus directory.
-        corpus_dir_name (str): Name of the corpus.
-        filename (str): Text file to process.
-        processed_dir (str): Output directory for processed corpora.
-
-    Returns:
-        None
     """
     file_path = os.path.join(corpus_dir_path, filename)
     separator, line_prefix = None, ''
+
     if corpus_dir_name in ['joemo', 'joff+', 'jofun', 'josa']:
         separator = {'str': ' ||| ', 'idx': 0}
     elif corpus_dir_name == 'gua_spa':
@@ -790,29 +833,24 @@ def prepare_processing_txt_corpus(corpus_dir_path, corpus_dir_name, filename,
         line_prefix = '#'
     elif corpus_dir_name == 'grammar':
         separator = {'str': '.,', 'idx': 1}
-    process_txt_corpus(file_path, processed_dir, corpus_dir_name, 
-                       separator=separator, line_prefix=line_prefix)
+
+    process_txt_corpus(
+        file_path,
+        processed_dir,
+        corpus_dir_name,
+        separator=separator,
+        line_prefix=line_prefix
+    )
 
 
-def prepare_processing_tsv_corpus(corpus_dir_path, corpus_dir_name, filename, 
+def prepare_processing_tsv_corpus(corpus_dir_path, corpus_dir_name, filename,
                                   processed_dir):
     """
     Configure and process a TSV-based corpus.
-
-    Handles specific corpus schemas (e.g., AmericasNLP variants, Tatoeba),
-    and sanitizes TSV files if necessary before processing.
-
-    Args:
-        corpus_dir_path (str): Path to corpus directory.
-        corpus_dir_name (str): Corpus name identifier.
-        filename (str): TSV file to process.
-        processed_dir (str): Output directory.
-
-    Returns:
-        None
     """
     file_path = os.path.join(corpus_dir_path, filename)
     names = None
+
     if corpus_dir_name == 'americasnlp2022':
         text_col_name = 'source_processed'
     elif corpus_dir_name == 'americasnli':
@@ -830,60 +868,42 @@ def prepare_processing_tsv_corpus(corpus_dir_path, corpus_dir_name, filename,
         text_col_name = 'sentence'
     else:
         raise Exception(f'Unknown corpus in path {corpus_dir_path}')
+
     sanitize_tsv_corpus(file_path)
-    process_csv_corpus(file_path, processed_dir, corpus_dir_name, text_col_name, 
-                       sep='\t', names=names)
+
+    process_csv_corpus(
+        file_path,
+        processed_dir,
+        corpus_dir_name,
+        text_col_name,
+        sep='\t',
+        names=names
+    )
 
 
-def prepare_processing_xml_corpus(corpus_dir_path, corpus_dir_name, filename, 
+def prepare_processing_xml_corpus(corpus_dir_path, corpus_dir_name, filename,
                                   processed_dir):
     """
     Prepare and process an XML corpus file.
-
-    Args:
-        corpus_dir_path (str): Directory containing the XML corpus.
-        corpus_dir_name (str): Corpus name identifier.
-        filename (str): XML file name.
-        processed_dir (str): Directory to save processed corpus.
-
-    Returns:
-        None
     """
     file_path = os.path.join(corpus_dir_path, filename)
     process_xml_corpus(file_path, processed_dir, corpus_dir_name)
 
 
-def prepare_processing_jsonl_corpus(corpus_dir_path, corpus_dir_name, filename, 
-                                   processed_dir):
+def prepare_processing_jsonl_corpus(corpus_dir_path, corpus_dir_name, filename,
+                                    processed_dir):
     """
     Prepare and process a JSONL corpus file.
-
-    Args:
-        corpus_dir_path (str): Path to corpus directory.
-        corpus_dir_name (str): Name of corpus.
-        filename (str): JSONL file name.
-        processed_dir (str): Output directory.
-
-    Returns:
-        None
     """
     file_path = os.path.join(corpus_dir_path, filename)
     process_jsonl_corpus(file_path, processed_dir, corpus_dir_name)
 
-def prepare_processing_json_corpus(corpus_dir_path, corpus_dir_name, filename, processed_dir):
+
+def prepare_processing_json_corpus(corpus_dir_path, corpus_dir_name, filename,
+                                   processed_dir):
     """
     Prepare and process a JSON corpus file.
-
-    Args:
-        corpus_dir_path (str): Path to corpus directory.
-        corpus_dir_name (str): Name of corpus.
-        filename (str): JSON file name.
-        processed_dir (str): Output directory.
-
-    Returns:
-        None
     """
-
     file_path = os.path.join(corpus_dir_path, filename)
     process_json_corpus(file_path, processed_dir, corpus_dir_name)
 
@@ -891,57 +911,72 @@ def prepare_processing_json_corpus(corpus_dir_path, corpus_dir_name, filename, p
 def process_corpora(raw_corpora_dir_path, processed_corpora_dir, overwrite=False):
     """
     Process all supported corpus files in a directory tree.
-
-    Detects corpus format by file extension and dispatches to the appropriate
-    processing routine (CSV, TXT, TSV, XML, JSONL).
-
-    Args:
-        dir_path (str): Path to directory containing corpora.
-        processed_corpora_dir (str): Directory to store processed results.
-
-    Returns:
-        None
     """
     os.makedirs(processed_corpora_dir, exist_ok=True)
+
     for corpus_dir_name in os.listdir(raw_corpora_dir_path):
         corpus_path = os.path.join(raw_corpora_dir_path, corpus_dir_name)
         processed_corpus_dir = os.path.join(processed_corpora_dir, corpus_dir_name)
-        corpus_report_file_path = os.path.join(processed_corpus_dir, f'{corpus_dir_name}_report.json')
+        corpus_report_file_path = os.path.join(
+            processed_corpus_dir,
+            f'{corpus_dir_name}_report.json'
+        )
+
         if os.path.exists(corpus_report_file_path):
             if not overwrite:
-                # if not overwrite and corpus report exists ignore
                 continue
-            else:
-                # if overwrite and corpus report exists delete together with
-                # the processed corpus
-                os.remove(corpus_report_file_path)
-                corpus_file_path = os.path.join(processed_corpus_dir, f'{corpus_dir_name}.jsonl')
-                os.remove(corpus_file_path)
+
+            os.remove(corpus_report_file_path)
+            corpus_file_path = os.path.join(
+                processed_corpus_dir,
+                f'{corpus_dir_name}.jsonl'
+            )
+            os.remove(corpus_file_path)
+
         corpus_file_names = get_corpus_file_names(corpus_path)
+
         for filename in corpus_file_names:
             if filename.endswith('.csv'):
                 prepare_processing_csv_corpus(
-                    corpus_path, corpus_dir_name, filename, processed_corpora_dir
+                    corpus_path,
+                    corpus_dir_name,
+                    filename,
+                    processed_corpora_dir
                 )
             elif filename.endswith('.gn') or filename.endswith('.txt'):
                 prepare_processing_txt_corpus(
-                    corpus_path, corpus_dir_name, filename, processed_corpora_dir
+                    corpus_path,
+                    corpus_dir_name,
+                    filename,
+                    processed_corpora_dir
                 )
             elif filename.endswith('tsv'):
                 prepare_processing_tsv_corpus(
-                    corpus_path, corpus_dir_name, filename, processed_corpora_dir
+                    corpus_path,
+                    corpus_dir_name,
+                    filename,
+                    processed_corpora_dir
                 )
             elif filename.endswith('xml'):
                 prepare_processing_xml_corpus(
-                    corpus_path, corpus_dir_name, filename, processed_corpora_dir
+                    corpus_path,
+                    corpus_dir_name,
+                    filename,
+                    processed_corpora_dir
                 )
             elif filename.endswith('jsonl'):
                 prepare_processing_jsonl_corpus(
-                    corpus_path, corpus_dir_name, filename, processed_corpora_dir
+                    corpus_path,
+                    corpus_dir_name,
+                    filename,
+                    processed_corpora_dir
                 )
             elif filename.endswith('.json'):
                 prepare_processing_json_corpus(
-                    corpus_path, corpus_dir_name, filename, processed_corpora_dir
+                    corpus_path,
+                    corpus_dir_name,
+                    filename,
+                    processed_corpora_dir
                 )
             else:
                 print(f'Extension of the file {filename} is not supported')
@@ -950,114 +985,112 @@ def process_corpora(raw_corpora_dir_path, processed_corpora_dir, overwrite=False
 def compute_num_raw_records(raw_corpora_dir):
     """
     Compute the number of raw records across all corpora.
-
-    Inspects each corpus file, counts raw text records, and accounts for 
-    format-specific nuances (e.g., line filtering).
-
-    Args:
-        raw_corpora_dir (str): Directory containing unprocessed corpora.
-
-    Returns:
-        dict: Mapping of corpus name → number of raw records.
     """
     raw_records = {}
+
     for corpus_dir_name in os.listdir(raw_corpora_dir):
         raw_records[corpus_dir_name] = 0
         corpus_path = os.path.join(raw_corpora_dir, corpus_dir_name)
         corpus_file_names = get_corpus_file_names(corpus_path)
+
         for filename in corpus_file_names:
-            file_path = os.path.join(corpus_path, filename)            
+            file_path = os.path.join(corpus_path, filename)
+
             if filename.endswith('.csv'):
                 df = read_csv_corpus(file_path)
                 raw_records[corpus_dir_name] += df.shape[0]
+
             elif filename.endswith('.gn') or filename.endswith('.txt'):
                 file_content = read_txt_corpus(file_path)
+
                 if corpus_dir_name == 'gua_spa':
-                    # for the corpus gua_spa only lines starting with the pattern 
-                    # below should be included
-                    pattern = r"^#[A-Za-z0-9]+:" # (e.g., `#dev15:`, `#test179:`)
-                    text_lines = [line for line in file_content if re.match(pattern, line)]
+                    pattern = r"^#[A-Za-z0-9]+:"
+                    text_lines = [
+                        line for line in file_content
+                        if re.match(pattern, line)
+                    ]
                     raw_records[corpus_dir_name] += len(text_lines)
                 else:
                     raw_records[corpus_dir_name] += len(file_content)
+
             elif filename.endswith('.tsv'):
                 if corpus_dir_name == 'americasnli':
                     df = read_csv_corpus(file_path, '\t')
-                    raw_records[corpus_dir_name] += df.shape[0] + len(df['premise'].unique())
+                    raw_records[corpus_dir_name] += (
+                        df.shape[0] + len(df['premise'].unique())
+                    )
                 else:
                     names = None
+
                     if corpus_dir_name in ['americasnlp2024', 'tatoeba']:
                         names = ['col1', 'col2', 'col3']
                     elif corpus_dir_name in ['bible', 'ancora']:
                         names = ['col1', 'col2']
+
                     df = read_csv_corpus(file_path, '\t', names)
                     raw_records[corpus_dir_name] += df.shape[0]
+
             elif filename.endswith('xml'):
                 raw_records[corpus_dir_name] += len(read_xml_corpus(file_path))
+
             elif filename.endswith('jsonl'):
                 mult_factor = 1
+
                 if corpus_dir_name == 'belele':
-                    # for each record in raw belele two lines are created in the 
-                    # processed corpus, one line for the question
-                    # and the other for the `flores` passage. therefore, the
-                    # number of lines in the raw files is multipled by 2 to obtain
-                    # the total number of lines in the processed corpus
                     mult_factor = 2
-                raw_records[corpus_dir_name] += len(read_jsonl_corpus(file_path)) * mult_factor
+
+                raw_records[corpus_dir_name] += (
+                    len(read_jsonl_corpus(file_path)) * mult_factor
+                )
+
+            elif filename.endswith('.json'):
+                if corpus_dir_name == 'twitter_politic_bots':
+                    raw_records[corpus_dir_name] += sum(
+                        1 for _ in read_json_corpus(file_path)
+                    )
+
     return raw_records
 
 
 def check_processed_corpora(processed_corpora_dir, raw_records):
     """
     Validate that processed corpora match the expected record counts.
-
-    Cross-checks processed JSONL and report files against counts computed
-    from raw corpora. Raises assertion errors on mismatches.
-
-    Args:
-        processed_corpora_dir (str): Directory with processed corpora.
-        raw_records (dict): Mapping of corpus name → expected record count.
-
-    Returns:
-        None
     """
     for corpus_dir_name in os.listdir(processed_corpora_dir):
         print(f'Checking corpus {corpus_dir_name}...')
         corpus_path = os.path.join(processed_corpora_dir, corpus_dir_name)
         corpus_file_names = get_corpus_file_names(corpus_path)
+
         for filename in corpus_file_names:
             file_path = os.path.join(corpus_path, filename)
             raw_corpus_num_records = raw_records.get(corpus_dir_name, None)
+
             if not raw_corpus_num_records:
                 continue
+
             if filename.endswith('json'):
                 with open(file_path, 'r') as f:
                     processed_corpus_report = json.load(f)
+
                 assert processed_corpus_report['num_docs'] == raw_corpus_num_records, \
-                    f"Number of records reported for the copus {corpus_dir_name} is incorrect, "\
+                    f"Number of records reported for the copus {corpus_dir_name} is incorrect, " \
                     f"expected {raw_corpus_num_records}, reported {processed_corpus_report['num_docs']}"
+
             if filename.endswith('jsonl'):
                 processed_corpus_num_records = len(read_jsonl_corpus(file_path))
+
                 assert processed_corpus_num_records == raw_corpus_num_records, \
-                    f"Number of processed records for the corpus {corpus_dir_name} is inconsistent, "\
+                    f"Number of processed records for the corpus {corpus_dir_name} is inconsistent, " \
                     f"expected {raw_corpus_num_records}, processed {processed_corpus_num_records}"
+
         print(f'Ok {corpus_dir_name}!')
+
     print('Everything is correct!, the number of proccessed records matchs expectation for each corpus')
 
 
 def verify_processed_corpora(raw_corpora_dir, processed_corpora_dir):
     """
     Verify consistency between raw and processed corpora.
-
-    Combines record counting (`compute_num_raw_records`) and validation
-    (`check_processed_corpora`) into a full verification pipeline.
-
-    Args:
-        raw_corpora_dir (str): Directory with raw corpora.
-        processed_corpora_dir (str): Directory with processed corpora.
-
-    Returns:
-        None
     """
     raw_records = compute_num_raw_records(raw_corpora_dir)
     check_processed_corpora(processed_corpora_dir, raw_records)

--- a/src/utils.py
+++ b/src/utils.py
@@ -79,14 +79,22 @@ def identify_language(text):
             Returns None if the language is not 'grn'.
     """
     result = identifier.identify_languages(text, k=1, raw_output=False)
-    identified_lang = result['languages']
-    if identified_lang[0] == GN_CODE:
+    identified_lang = result["languages"]
+
+    if isinstance(identified_lang, dict):
+        lang = next(iter(identified_lang.keys()))
+        score = identified_lang[lang]
+    else:
+        lang = identified_lang[0]
+        score = identified_lang[1]
+
+    if lang == GN_CODE:
         return {
-            'lang': identified_lang[0], 
-            'score': identified_lang[1], 
-            'source_score': result['source'],
-            'voting_method': result['voting']
-        }
+            "lang": lang,
+            "score": score,
+            "source_score": result["source"],
+            "voting_method": result["voting"],
+    }
     return None
 
 


### PR DESCRIPTION
## Summary
Adds support for processing new Twitter datasets as candidate Guarani sources.

## Changes
- Added processing support for:
  - `twitter_giossa_october`
  - `twitter_politic_bots`
  - `twitter_covid_es`
  - `twitter_covid_py`
- Updated `processor.py` to read the correct text field for each dataset:
  - `Tweet` for Giossa-Gongora October
  - `text` for COVID datasets
  - `tweet_obj.full_text` for politic-bots
- Updated `utils.py` to handle different output formats from `LanguageIdentifier`
- Generated processed outputs under `data/processed/twitter_*`

## Notes
The raw Twitter files were not committed because some exceed GitHub's file size limit. This PR includes the processing support and generated processed outputs.

These datasets were not added to `gn_corpora.json` because they are still being evaluated as candidate sources, not confirmed Guarani corpora.

## Validation
- Ran the processing pipeline successfully
- Generated processed JSONL outputs with base metadata
- Kept the existing Guarani language filter to identify records detected as Guarani/Jopara