### PR TITLE
Update report with Twitter dataset results

### DIFF
--- a/data/gn_corpora.json
+++ b/data/gn_corpora.json
@@ -489,5 +489,53 @@
         "parallel": true,
         "synthetic": false,
         "license": "cc0-1.0"
+    },
+    {
+        "name": "twitter_giossa_october",
+        "url": "https://github.com/sgongora27/giossa-gongora-guarani-2021.git",
+        "download_urls": 
+            [
+            ],
+        "format": "csv",
+        "multilingual": true,
+        "parallel": false,
+        "synthetic": false,
+        "license": "Unknown"
+    },
+    {
+        "name": "twitter_politic_bots",
+        "url": "https://github.com/ParticipaPY/politic-bots.git",
+        "download_urls": 
+            [
+            ],
+        "format": "json",
+        "multilingual": true,
+        "parallel": false,
+        "synthetic": false,
+        "license": "GPL-3.0"
+    },
+    {
+        "name": "twitter_covid_es",
+        "url": "https://www.kaggle.com/datasets/mmaguero/covid19-spanishtweets-earlylateapril2020",
+        "download_urls": 
+            [
+            ],
+        "format": "csv",
+        "multilingual": true,
+        "parallel": false,
+        "synthetic": false,
+        "license": "CC BY-SA 4.0"
+    },
+    {
+        "name": "twitter_covid_py",
+        "url": "https://www.kaggle.com/datasets/mmaguero/covid19-spanishtweets-earlylateapril2020",
+        "download_urls": 
+            [
+            ],
+        "format": "csv",
+        "multilingual": true,
+        "parallel": false,
+        "synthetic": false,
+        "license": "CC BY-SA 4.0"
     }
 ]

--- a/report.md
+++ b/report.md
@@ -38,5 +38,9 @@ Publicly available corpora that contain text in Guarani.
 |32|[Opus-All-Es](https://opus.nlpl.eu/results/es&gn/corpus-result-table)|:white_check_mark:|:white_check_mark:| |Multiple|3,907|22,571|161,886|5.777|41.435|0.992| 
 |33|[Smolsent__En_Gn](https://huggingface.co/datasets/google/smol/viewer/smolsent__en_gn)|:white_check_mark:|:white_check_mark:| |CC BY 4.0|863|10,563|82,042|12.240|95.066|0.998| 
 |34|[Tatoeba](https://tatoeba.org/en/downloads)|:white_check_mark:| | |Creative Commons|3,367|13,269|95,040|3.941|28.227|0.939| 
-|35|[Udhr-Lid](https://huggingface.co/datasets/cis-lmu/udhr-lid)|:white_check_mark:|:white_check_mark:| |cc0-1.0|122|3,210|24,694|26.311|202.410|0.972| 
-| -- | Total | -- | -- | -- | -- | 1,244,399 | 37,317,099 | 273,698,871 | -- | -- | -- |  
+|35|[Twitter_Covid_Es](https://www.kaggle.com/datasets/mmaguero/covid19-spanishtweets-earlylateapril2020)|:white_check_mark:| | |CC BY-SA 4.0|20|729|5,495|36.450|274.750|0.995| 
+|36|[Twitter_Covid_Py](https://www.kaggle.com/datasets/mmaguero/covid19-spanishtweets-earlylateapril2020)|:white_check_mark:| | |CC BY-SA 4.0|2|72|525|36.000|262.500|0.994| 
+|37|[Twitter_Giossa_October](https://github.com/sgongora27/giossa-gongora-guarani-2021.git)|:white_check_mark:| | |Unknown|4,562|45,039|307,359|9.873|67.374|0.960| 
+|38|[Twitter_Politic_Bots](https://github.com/ParticipaPY/politic-bots.git)|:white_check_mark:| | |GPL-3.0|44|554|4,353|12.591|98.932|0.930| 
+|39|[Udhr-Lid](https://huggingface.co/datasets/cis-lmu/udhr-lid)|:white_check_mark:|:white_check_mark:| |cc0-1.0|122|3,210|24,694|26.311|202.410|0.972| 
+| -- | Total | -- | -- | -- | -- | 1,249,027 | 37,363,493 | 274,016,603 | -- | -- | -- |  


### PR DESCRIPTION
## Summary
Updates the corpus report to include the newly processed Twitter candidate datasets.

## Changes
- Added Twitter dataset entries to `data/gn_corpora.json`:
  - `twitter_giossa_october`
  - `twitter_politic_bots`
  - `twitter_covid_es`
  - `twitter_covid_py`
- Regenerated `report.md` using the existing `create_report()` flow.
- Added the corresponding statistics from the processed Twitter outputs.

## Notes
- The raw Twitter files are not committed because some exceed GitHub's file size limit.
- `download_urls` were left empty because these sources are not currently downloaded through the repository downloader.
- The COVID Twitter entries use the Kaggle dataset URL as the reference source.
- These datasets are included as candidate Guarani/Jopara sources based on the processed outputs.

## Validation
- Validated `data/gn_corpora.json` with `python -m json.tool`.
- Regenerated `report.md` successfully.
- Verified that the Twitter entries appear in the report.